### PR TITLE
Release/2.1.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,8 @@ def get_version():
 
 
 version = get_version()
+readme = get_readme()
+
 setuptools.setup(
     name="ods_tools",
     version=version,
@@ -39,7 +41,7 @@ setuptools.setup(
     package_dir={'ods_tools': 'src', 'OpenExposureData/Docs': 'OpenExposureData/Docs'},
     python_requires='>=3.7',
     description='Tools to manage ODS files',
-    long_description=get_readme(),
+    long_description=readme,
     long_description_content_type='text/markdown',
     url='https://github.com/OasisLMF/OpenDataStandards',
 )

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '2.0.1'
+__version__ = '2.1.1'
 from .oed import *
 
 import logging


### PR DESCRIPTION
## Fix package installation issue 

Installation of the wheel seems to be broken when trying to install `ods-tools==2.1.0.post1`,  installing for source also fails with an error trying to fetch the readme file. Releasing a patch as version `2.1.1`
```
 ERROR: Command errored out with exit status 1:
     command: /home/sam/repos/venv/dev/bin/python3.9 -c 'import io, os, sys, setuptools, tokenize; sys.argv[0] = '"'"'/tmp/pip-install-hcejn_xg/ods-tools_a15d137324d94a2392159978518e20a6/setup.py'"'"'; __file__='"'"'/tmp/pip-install-hcejn_xg/ods-tools_a15d137324d94a2392159978518e20a6/setup.py'"'"';f = getattr(tokenize, '"'"'open'"'"', open)(__file__) if os.path.exists(__file__) else io.StringIO('"'"'from setuptools import setup; setup()'"'"');code = f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' egg_info --egg-base /tmp/pip-pip-egg-info-pl5avgvj
         cwd: /tmp/pip-install-hcejn_xg/ods-tools_a15d137324d94a2392159978518e20a6/
    Complete output (7 lines):
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-install-hcejn_xg/ods-tools_a15d137324d94a2392159978518e20a6/setup.py", line 42, in <module>
        long_description=get_readme(),
      File "/tmp/pip-install-hcejn_xg/ods-tools_a15d137324d94a2392159978518e20a6/setup.py", line 11, in get_readme
        with io.open(os.path.join(SCRIPT_DIR, 'src', 'README.md'), encoding='utf-8') as readme:
    FileNotFoundError: [Errno 2] No such file or directory: '/tmp/pip-install-hcejn_xg/ods-tools_a15d137324d94a2392159978518e20a6/src/README.md'
    ----------------------------------------

``` 