### PR TITLE
Drop Py3.8 from ods-tools schema testing 

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -97,7 +97,7 @@ jobs:
     needs: build_package
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
 
     steps:
     - name: Clone ODS_Tools repo


### PR DESCRIPTION
<!--start_release_notes-->
### Drop Py3.8 from ods-tools schema testing 
ODS-tools dropped py3.8 as its out of support, the package now has syntax that fails tests with that version https://github.com/OasisLMF/ODS_Tools/pull/176 Align schema tests with that change.
<!--end_release_notes-->
